### PR TITLE
Initialize globals at the start of each process, so it works on Windows.

### DIFF
--- a/Crafting.py
+++ b/Crafting.py
@@ -50,6 +50,7 @@ def join(A, B):
 		return dict([(a, join(A.get(a), B.get(a))) for a in set(A.keys()) | set(B.keys())])
 
 def recipeworker(cmds, cList, mytime, xp_to_level, out_q):
+	Globals.init()
 	totals = {}
 	for cmd in cmds:
 		if len(cmd) == 2:
@@ -61,7 +62,6 @@ def recipeworker(cmds, cList, mytime, xp_to_level, out_q):
 	out_q.put(totals)
 
 def main():
-	Globals.init()
 	# Uncomment these lines if you are writing files to disk
 #	if not os.path.exists("de"):
 #		os.makedirs("de")


### PR DESCRIPTION
A very simple change to get things working on Windows, where a new process does not inherit state.  (See http://rhodesmill.org/brandon/2010/python-multiprocessing-linux-windows/ for details.)

This was the cause of issue #25 on Windows.